### PR TITLE
Add NLB in public subnet and forward traffic to NLB in private sub

### DIFF
--- a/parallelcluster/add-external-lb.sh
+++ b/parallelcluster/add-external-lb.sh
@@ -39,7 +39,6 @@ aws ec2 create-security-group --group-name my-security-group-$cluster --descript
 
 my_sg_id=`aws ec2 describe-security-groups --filters Name=group-name,Values=my-security-group-$cluster --query 'SecurityGroups[0].GroupId' --output text`
 
-aws ec2 authorize-security-group-ingress --group-id $my_sg_id --protocol tcp --port 8787 --cidr 0.0.0.0/0
 aws ec2 authorize-security-group-ingress --group-id $my_sg_id --protocol tcp --port 80 --cidr 0.0.0.0/0
 
 # Find internet gw 

--- a/parallelcluster/add-external-lb.sh
+++ b/parallelcluster/add-external-lb.sh
@@ -1,19 +1,46 @@
 #!/bin/bash
 export cluster="security"
-tempfile=`mktemp`
-aws elbv2 describe-tags --resource-arns $(aws elbv2 describe-target-groups --query 'TargetGroups[*].TargetGroupArn' --output text) --query "TagDescriptions[?Tags[?Key==\`parallelcluster:cluster-name\` && Value==\`$cluster\`]].ResourceArn" --output text > $tempfile
-target_group_arn=`cat $tempfile`
-rm -f $tempfile
+
+# Find existing internal LB ARN
+tempfile=$(mktemp)
+aws elbv2 describe-tags --resource-arns $(aws elbv2 describe-load-balancers --query 'LoadBalancers[*].LoadBalancerArn' --output text) \
+--query "TagDescriptions[?Tags[?Key=='parallelcluster:cluster-name' && Value=='$cluster']].ResourceArn" --output text > $tempfile
+internal_lb_arn=$(cat $tempfile)
+rm $tempfile
+
+# DNS Name of internal LB 
+internal_lb_dns=`aws elbv2 describe-load-balancers --load-balancer-arns $internal_lb_arn --query 'LoadBalancers[0].DNSName' --output text`
+
+# We need the head node id to inquire the IP address of the internal LB (the AWS API does not seem to expose the IP of a NLB)
+head_node_id=`pcluster describe-cluster --cluster-name="$cluster" | jq -r .headNode.instanceId`
+
+command="host $internal_lb_dns | awk '{print \$4}'"
+
+command_id=`aws ssm send-command --instance-ids "$head_node_id" \
+    --document-name "AWS-RunShellScript" \
+    --parameters 'commands=["'"$command"'"]' | jq -r .Command.CommandId`
+
+# IP address of internal NLB
+internal_lb_ip=`aws ssm get-command-invocation \
+    --command-id "$command_id" \
+    --instance-id "$head_node_id" | jq -r .StandardOutputContent`
 
 # Query VPC ID
-vpc_id=`aws elbv2 describe-target-groups --target-group-arns $target_group_arn  --query 'TargetGroups[0].VpcId' --output text`
+vpc_id=`aws elbv2 describe-load-balancers --load-balancer-arns $internal_lb_arn --query 'LoadBalancers[0].VpcId' --output text`
+
+# Create new Target group 
+aws elbv2 create-target-group --name private-nlb-tgt-group-$cluster --protocol TCP --port 8787 --vpc-id $vpc_id --target-type ip
+
+# Register target (use the ip of the internal  NLB)
+aws elbv2 register-targets --target-group-arn $(aws elbv2 describe-target-groups --names private-nlb-tgt-group-$cluster --query 'TargetGroups[0].TargetGroupArn' --output text) --targets Id=$internal_lb_ip
 
 # Add new SG
-aws ec2 create-security-group --group-name my-security-group-$cluster --description "Security group for port 8787 access from everywhere" --vpc-id $vpc_id
+aws ec2 create-security-group --group-name my-security-group-$cluster --description "Security group for port 80/8787 access from everywhere" --vpc-id $vpc_id
 
 my_sg_id=`aws ec2 describe-security-groups --filters Name=group-name,Values=my-security-group-$cluster --query 'SecurityGroups[0].GroupId' --output text`
 
 aws ec2 authorize-security-group-ingress --group-id $my_sg_id --protocol tcp --port 8787 --cidr 0.0.0.0/0
+aws ec2 authorize-security-group-ingress --group-id $my_sg_id --protocol tcp --port 80 --cidr 0.0.0.0/0
 
 # Find internet gw 
 my_ig_id=`aws ec2 describe-internet-gateways --filters Name=attachment.vpc-id,Values=$vpc_id --query 'InternetGateways[*].InternetGatewayId' --output text`
@@ -27,18 +54,10 @@ my_public_subnet_ids=`aws ec2 describe-route-tables --filters Name=route-table-i
 aws elbv2 create-load-balancer --name my-load-balancer-$cluster --subnets `echo $my_public_subnet_ids` --security-groups $my_sg_id --scheme internet-facing --type network 
 
 my_lb_arn=`aws elbv2 describe-load-balancers --names my-load-balancer-$cluster --query 'LoadBalancers[0].LoadBalancerArn' --output text`
-
-# Remove Listener from existing LB
-
-# Find existing LB ARN
-tempfile=`mktemp`
-aws elbv2 describe-tags --resource-arns $(aws elbv2 describe-load-balancers --query 'LoadBalancers[*].LoadBalancerArn' --output text) --query "TagDescriptions[?Tags[?Key==\`parallelcluster:cluster-name\` && Value==\`$cluster\`]].ResourceArn" --output text > $tempfile
-old_lb_arn=`cat $tempfile`
-rm $tempfile
-old_listener_arn=`aws elbv2 describe-listeners --load-balancer-arn $old_lb_arn --query 'Listeners[*].ListenerArn' --output text`
-
-aws elbv2 delete-listener --listener-arn $old_listener_arn
+target_group_arn=`aws elbv2 describe-target-groups --names private-nlb-tgt-group-$cluster --query 'TargetGroups[0].TargetGroupArn' --output text`
 
 # Create Listener that forwards traffix to target group in private subnet 
-aws elbv2 create-listener --load-balancer-arn $my_lb_arn --protocol TCP --port 8787 --default-actions Type=forward,TargetGroupArn=$target_group_arn
+aws elbv2 create-listener --load-balancer-arn $my_lb_arn --protocol TCP --port 80 --default-actions Type=forward,TargetGroupArn=$target_group_arn
+
+
 

--- a/parallelcluster/deploy.sh
+++ b/parallelcluster/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CLUSTERNAME="security"
+CLUSTERNAME="security2"
 STACKNAME="security2"
 PWB_VERSION="2024.12.0-465.pro3"
 #SECURITYGROUP_RSW="sg-04c08af1bcd95449d"

--- a/parallelcluster/fix-sg.sh
+++ b/parallelcluster/fix-sg.sh
@@ -1,4 +1,4 @@
-cluster="security3"
+cluster="security"
 my_ip=`curl ifconfig.me`
 
 tmpfile=`mktemp`
@@ -10,12 +10,12 @@ sgname=`echo $sgtext | awk '{print $2}'`
 echo ""
 echo "Found security group $sg ($sgname) with public ssh access" 
 echo "Limiting ssh access to IP address $my_ip"
-#aws ec2 revoke-security-group-ingress --group-id $sg --protocol tcp --port 22 --cidr "0.0.0.0/0"
-#aws ec2 authorize-security-group-ingress --group-id $sg --protocol tcp --port 22 --cidr "$my_ip/32"
+aws ec2 revoke-security-group-ingress --group-id $sg --protocol tcp --port 22 --cidr "0.0.0.0/0"
+aws ec2 authorize-security-group-ingress --group-id $sg --protocol tcp --port 22 --cidr "$my_ip/32"
 if [[ $sgname == *"LoginNode"* ]]; then
     echo "This looks like a Login node, lets's also add an ingress for ports 8787 and 443"
-#   aws ec2 authorize-security-group-ingress --group-id $sg --protocol tcp --port 8787 --cidr "0.0.0.0/0"
-#   aws ec2 authorize-security-group-ingress --group-id $sg --protocol tcp --port 443 --cidr "0.0.0.0/0"
+   aws ec2 authorize-security-group-ingress --group-id $sg --protocol tcp --port 8787 --cidr "0.0.0.0/0"
+   aws ec2 authorize-security-group-ingress --group-id $sg --protocol tcp --port 443 --cidr "0.0.0.0/0"
 fi
 done < ${tmpfile}
 rm -f $tmpfile 


### PR DESCRIPTION
In https://github.com/sol-eng/aws-parallelcluster-rsw-ha/pull/25 we have started to move all infrastructure into a private subnet. The only piece still remaining was the NLB for the login nodes.

In the same mentioned PR we have removed the AWS PC created NLB  in the private subnet and created a new one in the public subnet, pointing directly to the listener/target group that contains the login nodes. This is a fairly invasive operation to AWS ParallelCluster. 

In this PR we are now creating a new NLB in the public subnet (as before) but routing traffic to the IP adress of the AWS ParallelCluster generated NLB in the private subnet in order to avoid any tampering with the AWS PC infrastructure. 

Thanks @samcofer for this great suggestion. 

For now all of this lives in an extra bash script - at some point we can think of adding this to the pulumi recipes. 