### PR TITLE
Logrotate

### DIFF
--- a/parallelcluster/scripts/config-login.sh
+++ b/parallelcluster/scripts/config-login.sh
@@ -107,7 +107,7 @@ systemctl daemon-reload
 systemctl stop rstudio-server
 systemctl stop rstudio-launcher
 killall apache2 
-rm -rf /var/log/rstudio
+logrotate -f /etc/logrotate.d/rstudio
 systemctl start rstudio-launcher
 systemctl start rstudio-server
 

--- a/parallelcluster/scripts/config-login.sh
+++ b/parallelcluster/scripts/config-login.sh
@@ -33,6 +33,45 @@ do
     fi
 done 
 
+cat << EOF > /etc/logrotate.d/rstudio
+/var/log/rstudio/rstudio-server/*.log {
+    daily
+    missingok
+    rotate 7
+    compress
+    delaycompress
+    notifempty
+    create 0640 rstudio-server rstudio-server
+    su rstudio-server rstudio-server
+    sharedscripts
+    prerotate
+        systemctl stop rstudio-server
+    endscript
+    postrotate
+        systemctl start rstudio-server
+    endscript
+}
+
+/var/log/rstudio/launcher/*.log {
+    daily
+    missingok
+    rotate 7
+    compress
+    delaycompress
+    notifempty
+    create 0640 rstudio-server rstudio-server
+    su rstudio-server rstudio-server 
+    sharedscripts
+    prerotate
+        systemctl stop rstudio-launcher
+    endscript
+    postrotate
+        systemctl start rstudio-launcher
+    endscript
+}
+EOF
+
+systemctl restart logrotate
 
 VSCODE_EXTDIR=/usr/local/rstudio/code-server
 

--- a/parallelcluster/scripts/install-pwb-config.sh
+++ b/parallelcluster/scripts/install-pwb-config.sh
@@ -80,6 +80,7 @@ cat > $PWB_CONFIG_DIR/logging.conf << EOF
 [*]
 log-level=info
 logger-type=file
+rotate=0
 EOF
  
 cat > $PWB_CONFIG_DIR/rserver.conf << EOF
@@ -390,6 +391,7 @@ if (mount | grep login_nodes >&/dev/null) && [ ! -f /etc/head-node ]; then
                 systemctl stop rstudio-server 
                 systemctl stop rstudio-launcher
                 killall apache2
+                logrotate -f /etc/logrotate.d/rstudio
                 systemctl start rstudio-launcher
                 systemctl start rstudio-server 
                 touch /opt/rstudio/workbench-\`hostname\`.state


### PR DESCRIPTION
It seems like `logrotate` can be forced specifically for certain log files. This PR will add logrotate support (both regularly and on-demand) for PWB log files. PWB as such will be configured to NOT rotate log files itself as a consequence. 