### PR TITLE
Use VPC ip range as the default for inbound SSH traffic

### DIFF
--- a/parallelcluster/config/cluster-config-wb.benchmark.tmpl
+++ b/parallelcluster/config/cluster-config-wb.benchmark.tmpl
@@ -23,7 +23,8 @@ HeadNode:
       Size: 120 
   SharedStorageType: Efs
   Ssh:
-    KeyName: KEY 
+    KeyName: KEY
+    AllowedIps: ALLOWEDIPS 
 Image: 
   Os: ubuntu2204
   CustomAmi: AMI
@@ -97,7 +98,8 @@ LoginNodes:
         SubnetIds: 
           - SUBNETID
       Ssh:
-        KeyName: KEY 
+        KeyName: KEY
+        AllowedIps: ALLOWEDIPS 
 
 DevSettings:
   Timeouts:

--- a/parallelcluster/config/cluster-config-wb.default.tmpl
+++ b/parallelcluster/config/cluster-config-wb.default.tmpl
@@ -23,7 +23,8 @@ HeadNode:
       Size: 120 
   SharedStorageType: Efs
   Ssh:
-    KeyName: KEY 
+    KeyName: KEY
+    AllowedIps: ALLOWEDIPS
 Image: 
   Os: ubuntu2204
   CustomAmi: AMI
@@ -119,7 +120,8 @@ LoginNodes:
         SubnetIds: 
           - SUBNETID
       Ssh:
-        KeyName: KEY 
+        KeyName: KEY
+        AllowedIps: ALLOWEDIPS
       Iam:
         AdditionalIamPolicies:
           - Policy: S3_ACCESS

--- a/parallelcluster/config/cluster-config-wb.easybuild.tmpl
+++ b/parallelcluster/config/cluster-config-wb.easybuild.tmpl
@@ -21,6 +21,7 @@ HeadNode:
   SharedStorageType: Efs
   Ssh:
     KeyName: KEY 
+    AllowedIps: ALLOWEDIPS
 Image: 
   Os: ubuntu2204
   CustomAmi: AMI
@@ -116,7 +117,8 @@ LoginNodes:
         SubnetIds: 
           - SUBNETID
       Ssh:
-        KeyName: KEY 
+        KeyName: KEY
+        AllowedIps: ALLOWEDIPS 
 
 DevSettings:
   Timeouts:

--- a/parallelcluster/config/cluster-config-wb.ide-team.tmpl
+++ b/parallelcluster/config/cluster-config-wb.ide-team.tmpl
@@ -20,7 +20,8 @@ HeadNode:
       Size: 120
   SharedStorageType: Efs
   Ssh:
-    KeyName: KEY 
+    KeyName: KEY
+    AllowedIps: ALLOWEDIPS 
 Image: 
   Os: ubuntu2204
   CustomAmi: AMI
@@ -92,7 +93,8 @@ LoginNodes:
         SubnetIds: 
           - SUBNETID
       Ssh:
-        KeyName: KEY 
+        KeyName: KEY
+        AllowedIps: ALLOWEDIPS 
 
 DevSettings:
   Timeouts:

--- a/parallelcluster/deploy.sh
+++ b/parallelcluster/deploy.sh
@@ -12,6 +12,7 @@ EASYBUILD_SUPPORT=false
 CONFIG="default"
 HPC_DOMAIN=mayer.cx
 HPC_HOST="lance-launcher"
+ALLOWEDIPS="10.32.0.0/16"
 SSL=true
 LOCAL=true
 
@@ -119,6 +120,7 @@ cat config/cluster-config-wb.${CONFIG}.tmpl | \
 	sed "s#BILLING_CODE#${BILLING_CODE}#g" | \
         sed "s#SECURITYGROUP_SSH#${SECURITYGROUP_SSH}#g" | \
         sed "s#ELB_ACCESS#${ELB_ACCESS}#g" | \
+        sed "s#ALLOWEDIPS#${ALLOWEDIPS}#g" | \
 	sed "s#S3_ACCESS#${S3_ACCESS}#g" \
 	> tmp/cluster-config-wb.yaml
 


### PR DESCRIPTION
This resolves this issue and adds the restriction to the login nodes as well: 

https://github.com/sol-eng/aws-parallelcluster-rsw-ha/issues/36